### PR TITLE
Add Forest of Giant Plants to banlist

### DIFF
--- a/netlify/functions/validate/banlist.js
+++ b/netlify/functions/validate/banlist.js
@@ -2,4 +2,5 @@ module.exports = {
   "UPR 114": true,
   "PHF 99": true,
   "PHF 118": true,
+  "AOR 74": true,
 };

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -18,6 +18,18 @@
     <main>
       <h2>Changelog</h2>
 
+      <h3>15th January 2022</h3>
+      <ul>
+        <li>
+          Add Forest of Giant Plants to ban list.
+          <a
+            href="https://gymleaderchallenge.com/glc-update-1-1/"
+            target="_blank"
+            rel="noreferrer nofollow"
+            >Announcement here</a
+          >
+        </li>
+      </ul>
       <h3>17th November 2021</h3>
       <ul>
         <li>


### PR DESCRIPTION
[Newest GLC 1.1 update](https://gymleaderchallenge.com/glc-update-1-1/) added Forest of Giant Plants (AOR 74) into the ban list. 

Updated the app to take that into account.