### PR TITLE
Add support for Pokemon TCG Live decklist format

### DIFF
--- a/netlify/functions/validate/utils.js
+++ b/netlify/functions/validate/utils.js
@@ -6,7 +6,7 @@ function isBanned(card) {
 }
 
 function isValidCardLine(line) {
-  const pattern = /\* (\d+) (.*) ([A-Z-]{2,6}) (\d+)/;
+  const pattern = /(?:\* )?(\d+) (.*) ([A-Z-]{2,6}) (\d+)/;
   const matches = line.match(pattern);
 
   return matches;
@@ -66,6 +66,7 @@ function isSingleton(decklist) {
     "Fighting Energy",
     "Lightning Energy",
     "Psychic Energy",
+    "Basic {",
   ];
 
   decklist.forEach(([fullLine, quantity, name, set]) => {

--- a/netlify/functions/validate/utils.js
+++ b/netlify/functions/validate/utils.js
@@ -21,7 +21,6 @@ function isMonotype(decklist) {
       const setData = databaseCards[set];
       if (setData) {
         const cardData = setData[number];
-        console.log(cardData);
         return cardData;
       } else {
         return null;

--- a/netlify/functions/validate/validate.js
+++ b/netlify/functions/validate/validate.js
@@ -48,6 +48,7 @@ const handler = async (event) => {
 
     decklist.forEach((card) => {
       const [fullLine, qty, name, set, number] = card;
+      console.log(card);
       if (isBanned(`${set} ${number}`)) {
         checks.banned.valid = false;
         checks.banned.messages.push(fullLine);

--- a/netlify/functions/validate/validate.js
+++ b/netlify/functions/validate/validate.js
@@ -48,7 +48,6 @@ const handler = async (event) => {
 
     decklist.forEach((card) => {
       const [fullLine, qty, name, set, number] = card;
-      console.log(card);
       if (isBanned(`${set} ${number}`)) {
         checks.banned.valid = false;
         checks.banned.messages.push(fullLine);

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,10 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>24th February 2022</h3>
+      <ul>
+        <li>Add support for Pokemon TCG Live decklist format.</li>
+      </ul>
 
       <h3>15th January 2022</h3>
       <ul>

--- a/web/index.html
+++ b/web/index.html
@@ -35,7 +35,7 @@
       </p>
       <h2>How to use</h2>
       <p>
-          Copy-paste your deck in PTCGO format to the text box below and hit <em>Check legality</em> button.
+          Copy-paste your deck in PTCGO or PTCGL format to the text box below and hit <em>Check legality</em> button.
       </p>
       <h2>Decklist</h2>
       <form>


### PR DESCRIPTION
This update adds support for decklist exports from the new Pokemon TCG Live, a replacement for Pokemon TCG Online, that is now in open beta for Canadian players.

It's possible that the export format will change between now and the official launch and since the current Live version only supports cards from Sun and Moon onwards, it's very unlikely to be a popular playing ground for Gym Leader Challenge but I made this update in case there are some who do.