### PR TITLE
Add support for Astral Radiance (ASR) set

### DIFF
--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -120,15 +120,16 @@ async function download(setCode, { force }) {
     let ruleBox = false;
 
     if (
-      subtypes &&
-      (subtypes.includes("EX") ||
-        subtypes.includes("GX") ||
-        subtypes.includes("BREAK") ||
-        subtypes.includes("V") ||
-        subtypes.includes("VMAX") ||
-        subtypes.includes("VSTAR") ||
-        rarity === "Rare ACE" ||
-        name.includes("◇"))
+      (subtypes &&
+        (subtypes.includes("EX") ||
+          subtypes.includes("GX") ||
+          subtypes.includes("BREAK") ||
+          subtypes.includes("V") ||
+          subtypes.includes("VMAX") ||
+          subtypes.includes("VSTAR"))) ||
+      rarity === "Rare ACE" ||
+      rarity === "Radiant Rare" ||
+      name.includes("◇")
     ) {
       ruleBox = true;
     }

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,10 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>28th May 2022</h3>
+      <ul>
+        <li>Add support for Astral Radiance (ARS) and Radiant Pokemon</li>
+      </ul>
       <h3>25th February 2022</h3>
       <ul>
         <li>Add support for Brilliant Stars (BRS)</li>


### PR DESCRIPTION
Astral Radiance brings new Rule Box Pokemon in Radiant Pokemon.

This change adds support for those into the tool.

[The app](https://glc-checker.netlify.app/) is also updated at with the new cards.