### PR TITLE
Add Hiker and Chip Chip Ice Axe to ban list

### DIFF
--- a/netlify/functions/validate/banlist.js
+++ b/netlify/functions/validate/banlist.js
@@ -1,1 +1,1 @@
-module.exports = {"UPR 114":true,"PHF 99":true,"PHF 118":true};
+module.exports = {"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true};

--- a/tooling/data/banlist.json
+++ b/tooling/data/banlist.json
@@ -1,1 +1,1 @@
-{"UPR 114":true,"PHF 99":true,"PHF 118":true}
+{"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true}


### PR DESCRIPTION
Per [newest GLC 1.2 update](https://gymleaderchallenge.com/glc-update-1-2/) both of these cards have been banned.