### PR TITLE
Support Lost Origins, fix promos & special subsets.

### DIFF
--- a/netlify/functions/validate/utils.js
+++ b/netlify/functions/validate/utils.js
@@ -16,7 +16,7 @@ function isMonotype(decklist) {
   const types = decklist
     .map((card) => {
       const set = card[3];
-      const number = card[4];
+      const number = getSubsettedNumber(set, card[4]);
 
       const setData = databaseCards[set];
       if (setData) {
@@ -92,9 +92,44 @@ function isSingleton(decklist) {
   };
 }
 
+/*
+ * There are a few sets that have a differently numbered subset.
+ * PTCGO uses its own numbering for those, one that is not consistent
+ * with printed cards nor the API so we need to convert those to right
+ * format ourselves.
+ */
+
+const subsets = {
+  LTR: { total: 115, prefix: "RC", leftPad: 0 },
+  GEN: { total: 100, prefix: "RC", leftPad: 0 },
+  SHF: { total: 73, prefix: "SV", leftPad: 3 },
+  BRS: { total: 186, prefix: "TG", leftPad: 2 },
+  ASR: { total: 216, prefix: "TG", leftPad: 2 },
+  LOR: { total: 217, prefix: "TG", leftPad: 2 },
+  "PR-SW": { total: 0, prefix: "SWSH", leftPad: 3 },
+  "PR-SM": { total: 0, prefix: "SM", leftPad: 0 },
+  "PR-XY": { total: 0, prefix: "XY", leftPad: 2 },
+  "PR-BLW": { total: 0, prefix: "BW", leftPad: 2 },
+};
+
+function getSubsettedNumber(ptcgoCode, number) {
+  if (subsets.hasOwnProperty(ptcgoCode)) {
+    const subset = subsets[ptcgoCode];
+    let { total, prefix, leftPad } = subset;
+    if (number <= total) {
+      return number.toString();
+    }
+    let newNumber = number - total;
+    return `${prefix}${newNumber.toString().padStart(leftPad, "0")}`;
+  } else {
+    return number.toString();
+  }
+}
+
 module.exports = {
   isBanned,
   isValidCardLine,
   isMonotype,
   isSingleton,
+  getSubsettedNumber,
 };

--- a/netlify/functions/validate/validate.js
+++ b/netlify/functions/validate/validate.js
@@ -3,6 +3,7 @@ const {
   isMonotype,
   isSingleton,
   isBanned,
+  getSubsettedNumber,
 } = require("./utils.js");
 
 const databaseCards = require("./cards.js");
@@ -47,7 +48,8 @@ const handler = async (event) => {
     checks.singleton = isSingleton(decklist);
 
     decklist.forEach((card) => {
-      const [fullLine, qty, name, set, number] = card;
+      let [fullLine, qty, name, set, number] = card;
+      number = getSubsettedNumber(set, number);
       if (isBanned(`${set} ${number}`)) {
         checks.banned.valid = false;
         checks.banned.messages.push(fullLine);
@@ -63,6 +65,7 @@ const handler = async (event) => {
         return;
       }
       const cardData = setData[number];
+      console.log(cardData);
 
       if (!cardData) {
         checks.unknown_cards.valid = false;

--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -62,6 +62,7 @@ async function downloadSet() {
       },
     ]);
     setCode = setCode.setCode;
+    console.log(setCode);
   } else if (setCode === "100") {
     const allAvailableSets = await getAllSets();
     allAvailableSets.forEach(async (set) => {

--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -62,7 +62,6 @@ async function downloadSet() {
       },
     ]);
     setCode = setCode.setCode;
-    console.log(setCode);
   } else if (setCode === "100") {
     const allAvailableSets = await getAllSets();
     allAvailableSets.forEach(async (set) => {

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,14 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>10th September 2022</h3>
+      <ul>
+        <li>Add support for Lost Origins (LOR) set.</li>
+        <li>
+          Finally support promos and special subsets (like Radiant Collection
+          and Trainer Gallery).
+        </li>
+      </ul>
       <h3>13th July 2022</h3>
       <ul>
         <li>Add support for Pokemon GO (PGO) set.</li>

--- a/web/index.html
+++ b/web/index.html
@@ -53,11 +53,6 @@
       <div id="result">
           <em>Submit a decklist to see results</em>
       </div>
-
-      <h2>Current known issues</h2>
-      <ul>
-          <li>Promo cards and special sub-collections like Radiant Collections are currently unverified due to inconsistencies between PTCGO and the API.</li>
-      </ul>
     </main>
 
     <footer>


### PR DESCRIPTION
Finally GLC Decklist Validator should recognize all cards correctly.

This work is thanks to work I did earlier for [my Firefox browser extension](https://addons.mozilla.org/en-GB/firefox/addon/pokemon-tcg-card-viewer/).