### PR TITLE
Added support for Heart Gold & Soul Silver cards with future reprints

### DIFF
--- a/netlify/functions/validate/validate.js
+++ b/netlify/functions/validate/validate.js
@@ -73,6 +73,14 @@ const handler = async (event) => {
         return;
       }
 
+      if(!cardData.setLegal) {
+        checks.legal_sets.valid = false;
+        checks.legal_sets.messages.push(
+          `${cardData.name} (${cardData.ptcgoCode} ${cardData.number}) is not from a legal set.`
+        );
+        return;
+      }
+
       if (cardData.ruleBox) {
         checks.rulebox.valid = false;
         checks.rulebox.messages.push(fullLine);

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,10 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>12th November 2022</h3>
+      <ul>
+        <li>Add support for cards from HeartGold & SoulSilver (HS), Unleashed (UL) and Call of Legends (CL) that have a legal and valid reprint from Expanded sets.</li>
+      </ul>
       <h3>11th November 2022</h3>
       <ul>
         <li>Add support for Silver Tempest (SIT) set.</li>


### PR DESCRIPTION
These cards are:

```
* 1 Magikarp HS 72
* 1 Copycat HS 90
* 1 Energy Switch HS 91
* 1 Fisherman HS 92
* 1 Full Heal HS 93
* 1 Moomoo Milk HS 94
* 1 Poké Ball HS 95
* 1 Pokégear3.0 HS 96
* 1 Pokémon Communication HS 98
* 1 Switch HS 102
* 1 Double Colorless Energy HS 103
* 1 Rainbow Energy HS 104

* 1 Magikarp CL 61
* 1 Copycat CL 77

* 1 Judge UL 78
* 1 Life Herb UL 79
* 1 PlusPower UL 80
* 1 Rare Candy UL 82
```

Fixes #14 