### PR TITLE
Bugfix: Expanded's banned cards showed incorrectly as "non-legal sets"

### DIFF
--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -131,7 +131,11 @@ async function download(setCode, { force }) {
       rarity,
     } = card;
 
-    const setLegal = legalities.expanded === "Legal";
+    // The API keeps list of expanded format ban list by stating it as "Banned" in
+    // legalities and since GLC uses a different ban list, it would make cards show up
+    // as "from non-legal sets" if the latter part of this or is missing.
+    const setLegal =
+      legalities.expanded === "Legal" || legalities.expanded === "Banned";
     const ptcgoCode = set.ptcgoCode;
 
     let ruleBox = false;

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,13 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>21st January 2023</h3>
+      <ul>
+        <li>
+          Fixed a bug that caused all Expanded format banned cards to show up as
+          invalid.
+        </li>
+      </ul>
       <h3>20th January 2023</h3>
       <ul>
         <li>Add support for Crown Zenith (CRZ) set.</li>


### PR DESCRIPTION
The API returns the expanded legality of cards banned in expanded as "Banned" and I only checked for "Legal", imagining the only options was "Legal".

Since Gym Leader Challenge has its own ban list, these cards showed up incorrectly in the validation results.

This update treats "Banned" cards as legal (and checks for the real ban list separately).