### PR TITLE
Add support for SVI

### DIFF
--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -116,7 +116,13 @@ async function download(setCode, { force }) {
     return;
   }
 
-  const cards = await pokemon.card.all({ q: `set.ptcgoCode:${setCode}` });
+  let cards;
+  if (setCode === "SVI") {
+    cards = await pokemon.card.all({ q: `set.id:sv1` });
+    cards = cards.map((card) => ({ ...card, ptcgoCode: "SVI" }));
+  } else {
+    cards = await pokemon.card.all({ q: `set.ptcgoCode:${setCode}` });
+  }
 
   const cardDetails = cards.map((card) => {
     const {
@@ -147,7 +153,9 @@ async function download(setCode, { force }) {
           subtypes.includes("BREAK") ||
           subtypes.includes("V") ||
           subtypes.includes("VMAX") ||
-          subtypes.includes("VSTAR"))) ||
+          subtypes.includes("VSTAR") ||
+          subtypes.includes("Tera ex") ||
+          subtypes.includes("ex"))) ||
       rarity === "Rare ACE" ||
       rarity === "Radiant Rare" ||
       name.includes("◇")

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,7 +17,11 @@
     </nav>
     <main>
       <h2>Changelog</h2>
-      <h3>18st March 2023</h3>
+      <h3>1st April 2023</h3>
+      <ul>
+        <li>Add support for Scarlet & Violet (SVI) set.</li>
+      </ul>
+      <h3>18th March 2023</h3>
       <ul>
         <li>
           Fixed a bug where Marshadow PR-SM 85 (Let loose) was marked as from


### PR DESCRIPTION
Scarlet & Violet set arrived, this adds support for it.

Since SVI is not available in PTCGO, this is a quick hack that requires more in-depth refactoring once I add full PTCGL support.