### PR TITLE
Fix bug with Celebrations set showing wrong cards

### DIFF
--- a/netlify/functions/validate/utils.js
+++ b/netlify/functions/validate/utils.js
@@ -6,7 +6,7 @@ function isBanned(card) {
 }
 
 function isValidCardLine(line) {
-  const pattern = /(?:\* )?(\d+) (.*) ([A-Z-]{2,6}) (\d+)/;
+  const pattern = /(?:\* )?(\d+) (.*) ([A-Z-/]{2,6}) (\d+)/;
   const matches = line.match(pattern);
 
   return matches;

--- a/netlify/functions/validate/validate.js
+++ b/netlify/functions/validate/validate.js
@@ -50,7 +50,6 @@ const handler = async (event) => {
     checks.singleton = isSingleton(decklist);
     checks.research = hasOnlyOneResearch(decklist);
     checks.lysandre = hasOnlyOneLysandre(decklist);
-    console.log(checks);
 
     decklist.forEach((card) => {
       let [fullLine, qty, name, set, number] = card;
@@ -63,11 +62,15 @@ const handler = async (event) => {
       const setData = databaseCards[set];
 
       if (!setData) {
-        checks.legal_sets.valid = false;
-        checks.legal_sets.messages.push(
-          `${set} is either not legal or not yet in the database`
-        );
-        return;
+        // Zekrom or Reshiram from Celebrations classic collection are legal
+        // so we need to skip this step in their case
+        if (!(set === "N/A" && (number === "20" || number === "21"))) {
+          checks.legal_sets.valid = false;
+          checks.legal_sets.messages.push(
+            `${set} is either not legal or not yet in the database`
+          );
+          return;
+        }
       }
       const cardData = setData[number];
       console.log(cardData);

--- a/tooling/utils.js
+++ b/tooling/utils.js
@@ -117,9 +117,21 @@ async function download(setCode, { force }) {
   }
 
   let cards;
+  /**
+   * SVI is the first set that's not in PTCGO
+   * so to keep the rest of the code simple,
+   * a hack here.
+   */
   if (setCode === "SVI") {
     cards = await pokemon.card.all({ q: `set.id:sv1` });
     cards = cards.map((card) => ({ ...card, ptcgoCode: "SVI" }));
+  } else if (setCode === "CEL") {
+  /**
+   * Both Celebrations and Celebrations: Classic Collection
+   * have the same CEL code in PTCGO. Since Classic Collection
+   * cards are not legal in GLC, we download only the main set
+   */
+    cards = await pokemon.card.all({ q: `set.id:cel25` });
   } else {
     cards = await pokemon.card.all({ q: `set.ptcgoCode:${setCode}` });
   }

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,11 +17,18 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>4th April 2023</h3>
+      <ul>
+        <li>
+          Fix a bug with Celebrations set that caused wrong cards to be used for
+          validation.
+        </li>
+      </ul>
       <h3>3rd April 2023</h3>
       <ul>
         <li>
           Validate that there's only one of Lysandre/Boss's Orders and only one
-          of Juniper/Sycamore/Professor's Research
+          of Juniper/Sycamore/Professor's Research.
         </li>
       </ul>
       <h3>1st April 2023</h3>


### PR DESCRIPTION
PTCGO code CEL is used with both Celebrations main set and the Classic Collection subset. And since we just check CEL + number, it led to wrong cards to being validated.

There are two cards from Classic Collection that are legal: Zekrom and Reshiram. PTCGO exports them with set code "N/A" so there's a special case to deal with them.