### PR TITLE
Nov 1st 2023: Add Research Lab (UNM 205) to banlist

### DIFF
--- a/netlify/functions/validate/banlist.js
+++ b/netlify/functions/validate/banlist.js
@@ -1,1 +1,1 @@
-module.exports = {"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true,"SHF 21":true};
+module.exports = {"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true,"SHF 21":true,"UNM 205":true};

--- a/tooling/data/banlist.json
+++ b/tooling/data/banlist.json
@@ -1,1 +1,1 @@
-{"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true,"SHF 21":true}
+{"UPR 114":true,"PHF 99":true,"PHF 118":true,"UNB 165":true,"CES 133":true,"SHF 21":true,"UNM 205":true}

--- a/web/changelog.html
+++ b/web/changelog.html
@@ -17,6 +17,20 @@
     </nav>
     <main>
       <h2>Changelog</h2>
+      <h3>1st November 2023</h3>
+      <ul>
+        <li>
+          Add
+          <a
+            href="https://pkmncards.com/card/pokemon-research-lab-unified-minds-unm-205/"
+            >Research Lab (UNM 205)</a
+          >
+          to banlist, according to
+          <a href="https://gymleaderchallenge.com/blog/glc-update-14"
+            >GLC 1.4 update</a
+          >.
+        </li>
+      </ul>
       <h3>23rd September 2023</h3>
       <ul>
         <li>Add support for set 151.</li>


### PR DESCRIPTION
As announced in [the 1.4 update for Gym Leader Challenge](https://gymleaderchallenge.com/blog/glc-update-14), Research Lab stadium card is banned, effective Nov 1st, 2023.

> Effective Wednesday, November 1, 2023, Pokémon Research Lab UNM 205/236 will no longer be legal for play in Gym Leader Challenge format. Pokémon Research Lab consistently accelerates Pokémon that evolve from Unidentified Fossil into play as early as the first turn of the game while going first, which can grant an unfair advantage to Fossil based decks. Besides putting evolution Pokémon into play instantly, the Stadium also circumvents the singleton rule of GLC by placing two Pokémon that both evolve from the same Pokémon into play at the same time.